### PR TITLE
Bilateral filter with start and end mask (Linux) [SCAN-984]

### DIFF
--- a/modules/cudaimgproc/include/opencv2/cudaimgproc.hpp
+++ b/modules/cudaimgproc/include/opencv2/cudaimgproc.hpp
@@ -700,11 +700,13 @@ CV_EXPORTS Ptr<TemplateMatching> createTemplateMatching(int srcType, int method,
 @param borderMode Border type. See borderInterpolate for details. BORDER_REFLECT101 ,
 BORDER_REPLICATE , BORDER_CONSTANT , BORDER_REFLECT and BORDER_WRAP are supported for now.
 @param stream Stream for the asynchronous version.
+@param outMaskStart - output cutting start
+@param outMaskEnd - output cutting end 
 
 @sa bilateralFilter
  */
 CV_EXPORTS void bilateralFilter(InputArray src, OutputArray dst, int kernel_size, float sigma_color, float sigma_spatial,
-                                int borderMode = BORDER_DEFAULT, Stream& stream = Stream::Null());
+    int borderMode = BORDER_DEFAULT, Stream& stream = Stream::Null(), int outMaskStart = 0, int outMaskEnd = 0);
 
 ///////////////////////////// Blending ////////////////////////////////
 

--- a/modules/cudaimgproc/src/bilateral_filter.cpp
+++ b/modules/cudaimgproc/src/bilateral_filter.cpp
@@ -41,13 +41,14 @@
 //M*/
 
 #include "precomp.hpp"
+#include <iostream>
 
 using namespace cv;
 using namespace cv::cuda;
 
 #if !defined (HAVE_CUDA) || defined (CUDA_DISABLER)
 
-void cv::cuda::bilateralFilter(InputArray, OutputArray, int, float, float, int, Stream&) { throw_no_cuda(); }
+void cv::cuda::bilateralFilter(InputArray, OutputArray, int, float, float, int, Stream&, int, int) { throw_no_cuda(); }
 
 #else
 
@@ -56,15 +57,15 @@ namespace cv { namespace cuda { namespace device
     namespace imgproc
     {
         template<typename T>
-        void bilateral_filter_gpu(const PtrStepSzb& src, PtrStepSzb dst, int kernel_size, float sigma_spatial, float sigma_color, int borderMode, cudaStream_t stream);
+        void bilateral_filter_gpu(const PtrStepSzb& src, PtrStepSzb dst, int kernel_size, float sigma_spatial, float sigma_color, int borderMode, cudaStream_t stream, int outMaskStart, int outMaskEnd);
     }
 }}}
 
-void cv::cuda::bilateralFilter(InputArray _src, OutputArray _dst, int kernel_size, float sigma_color, float sigma_spatial, int borderMode, Stream& stream)
+void cv::cuda::bilateralFilter(InputArray _src, OutputArray _dst, int kernel_size, float sigma_color, float sigma_spatial, int borderMode, Stream& stream, int outMaskStart, int outMaskEnd)
 {
     using cv::cuda::device::imgproc::bilateral_filter_gpu;
 
-    typedef void (*func_t)(const PtrStepSzb& src, PtrStepSzb dst, int kernel_size, float sigma_spatial, float sigma_color, int borderMode, cudaStream_t s);
+    typedef void(*func_t)(const PtrStepSzb& src, PtrStepSzb dst, int kernel_size, float sigma_spatial, float sigma_color, int borderMode, cudaStream_t s, int outMaskStart, int outMaskEnd);
 
     static const func_t funcs[6][4] =
     {
@@ -92,8 +93,8 @@ void cv::cuda::bilateralFilter(InputArray _src, OutputArray _dst, int kernel_siz
 
     _dst.create(src.size(), src.type());
     GpuMat dst = _dst.getGpuMat();
-
-    func(src, dst, kernel_size, sigma_spatial, sigma_color, borderMode, StreamAccessor::getStream(stream));
+    func(src, dst, kernel_size, sigma_spatial, sigma_color, borderMode, StreamAccessor::getStream(stream),outMaskStart,outMaskEnd);
+    
 }
 
 #endif


### PR DESCRIPTION
- added two int parameters to cv::cuda::bilateralFilter
- usage: first N and last M rows are not changed by BF calculation, they are used for calculation of neighbourhood though
- tested on PC and on Barium
